### PR TITLE
Fix tree size handling in bst.remove() method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,6 +71,7 @@
     "list": "cpp",
     "memory": "cpp",
     "span": "cpp",
-    "print": "cpp"
+    "print": "cpp",
+    "functional": "cpp"
   },
 }

--- a/src/classes/tree/bst.h
+++ b/src/classes/tree/bst.h
@@ -84,7 +84,6 @@ template <typename T> class bst {
     */
     void remove(T key) {
         root = _remove(root, key);
-        _size--;
     }
 
     class Iterator;
@@ -272,11 +271,14 @@ template <typename T> class bst {
         } else {
             if (!root->left && !root->right) {
                 root = nullptr;
+                _size--;
             } else if (!root->left) {
                 std::shared_ptr<node> temp = root->right;
+                _size--;
                 return temp;
             } else if (!root->right) {
                 std::shared_ptr<node> temp = root->left;
+                _size--;
                 return temp;
             } else {
                 std::shared_ptr<node> temp = root->right;

--- a/tests/tree/bst.cc
+++ b/tests/tree/bst.cc
@@ -27,6 +27,17 @@ TEST_CASE("checking removals in bst") {
   std::vector<int> v = {-20, 2, 10, 23};
   std::vector<int> inorder = b1.inorder();
   REQUIRE(v == inorder);
+
+  bst<int> b2;
+  REQUIRE(b2.size() == 0);
+  b2.remove(10);
+  REQUIRE(b2.size() == 0);
+  b2.insert(5);
+  REQUIRE(b2.size() == 1);
+  b2.remove(10);
+  REQUIRE(b2.size() == 1);
+  b2.remove(5);
+  REQUIRE(b2.size() == 0);
 }
 
 TEST_CASE("checking search in bst") {


### PR DESCRIPTION
The existing code modified _size even when no
changes where made to the tree (for example, when
the value to be removed did not exist in the tree or 
the tree was empty).